### PR TITLE
3 tag groups need better collapse behavior

### DIFF
--- a/frontend/src/app/page.client.tsx
+++ b/frontend/src/app/page.client.tsx
@@ -2,17 +2,17 @@
 
 import {usePathname, useRouter, useSearchParams} from 'next/navigation'
 import {Tag, TagButton, TagGroup} from '@/app/components/Tag'
-import {OptionalChildProps} from '@/app/types/Props'
-import React from "react";
+import React from 'react';
 
 
-type TagFilterListProps = OptionalChildProps & {
+type TagFilterListProps = {
     showCounts?: boolean,
     group: TagGroup,
-    activeTags: Set<string>
+    activeTags: Set<string>,
+    startChecked?: boolean
 }
 
-export function TagFilterList({group, showCounts, children, activeTags}: TagFilterListProps) {
+export function TagFilterList ({group, showCounts, activeTags, startChecked}: TagFilterListProps) {
     const router = useRouter()
     const pathName = usePathname()
     const currentParams = useSearchParams()
@@ -33,25 +33,19 @@ export function TagFilterList({group, showCounts, children, activeTags}: TagFilt
     }
 
     return (
-        <>
-            <details className={"collapse collapse-arrow"}>
-                <summary className={"collapse-title text-xl font-medium"}>
-                    <div className={'divider'}>{group.group}{children}</div>
-                </summary>
-                <div className={"collapse-content"}>
-                    <div className={'flex flex-wrap gap-6 justify-around'}>
-                        {group.tags
-                            .sort((a: Tag, b: Tag) => b.count - a.count)
-                            .map((tag: Tag) => <TagButton tag={tag} checked={activeTags?.has(tag.tagId)}
-                                                          showCount={showCounts} key={tag.tagId}
-                                                          handleChanged={handleTagButtonChanged}/>)}
-                    </div>
-                </div>
-            </details>
-        </>
+        <div className={'collapse collapse-arrow'}>
+            <input type={'checkbox'} name={'filter-accordion'} className={'min-w-full'} defaultChecked={startChecked ?? false}/>
+            <div className={'collapse-title text-xl font-medium'}>
+                <div className={'divider'}>{group.group}</div>
+            </div>
+            <div className={'collapse-content flex flex-wrap gap-6 justify-around'}>
+                {group.tags
+                    .sort((a: Tag, b: Tag) => b.count - a.count)
+                    .map((tag: Tag) => <TagButton tag={tag} checked={activeTags?.has(tag.tagId)}
+                                                  showCount={showCounts} key={tag.tagId}
+                                                  handleChanged={handleTagButtonChanged}/>)
+                }
+            </div>
+        </div>
     )
 }
-
-
-
-

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -73,7 +73,7 @@ export default async function HomePage ({searchParams}: HomePageProps) {
             </nav>
             <PrimarySection>
                 <PrimaryContainer autoMargins>
-                    <div className={'flex flex-col-reverse sm:flex-col-reverse md:flex-col lg:flex-col'}>
+                    <div className={'flex flex-col-reverse md:flex-col'}>
                         <div className={"mt-5"}>
                             <Carousel>
                                 {shopData.length > 0 ? sliceSplit(shopData, 6)
@@ -87,10 +87,15 @@ export default async function HomePage ({searchParams}: HomePageProps) {
                                     }) : <p>No shops matching your filters.</p>}
                             </Carousel>
                         </div>
-                        <div className={'flex flex-col'}>
-                            <TagFilterList group={brewingTags} activeTags={tags}/>
+                        <div className={'block md:hidden'}>
+                            <TagFilterList group={brewingTags} activeTags={tags} startChecked/>
                             <TagFilterList group={serviceTags} activeTags={tags}/>
                             <TagFilterList group={busyTags} activeTags={tags}/>
+                        </div>
+                        <div className={'hidden md:block'}>
+                            <TagFilterList group={brewingTags} activeTags={tags} startChecked/>
+                            <TagFilterList group={serviceTags} activeTags={tags} startChecked/>
+                            <TagFilterList group={busyTags} activeTags={tags} startChecked/>
                         </div>
                     </div>
 

--- a/frontend/src/app/shop/[shopId]/page.client.tsx
+++ b/frontend/src/app/shop/[shopId]/page.client.tsx
@@ -16,6 +16,7 @@ type TagToggleGroupProps = {
     shopId: string,
     session?: Session,
     activeTags: string[],
+    startChecked?: boolean
     activeTagsSetter: React.Dispatch<React.SetStateAction<string[]>>
 }
 
@@ -51,20 +52,30 @@ export function TagToggleList ({tagData, shopId, session}: TagToggleListProps) {
     }
     return (
         <>
-            <TagToggleGroup group={brewingTags} shopId={shopId} session={session} activeTags={activeTags}
-                            activeTagsSetter={setActiveTags}/>
-            <TagToggleGroup group={busyTags} shopId={shopId} session={session} activeTags={activeTags}
-                            activeTagsSetter={setActiveTags}/>
-            <TagToggleGroup group={serviceTags} shopId={shopId} session={session} activeTags={activeTags}
-                            activeTagsSetter={setActiveTags}/>
+            <div className={'block md:hidden'}>
+                <TagToggleGroup group={brewingTags} shopId={shopId} session={session} activeTags={activeTags}
+                                activeTagsSetter={setActiveTags} startChecked/>
+                <TagToggleGroup group={busyTags} shopId={shopId} session={session} activeTags={activeTags}
+                                activeTagsSetter={setActiveTags}/>
+                <TagToggleGroup group={serviceTags} shopId={shopId} session={session} activeTags={activeTags}
+                                activeTagsSetter={setActiveTags}/>
+            </div>
+            <div className={'hidden md:block'}>
+                <TagToggleGroup group={brewingTags} shopId={shopId} session={session} activeTags={activeTags}
+                                activeTagsSetter={setActiveTags} startChecked/>
+                <TagToggleGroup group={busyTags} shopId={shopId} session={session} activeTags={activeTags}
+                                activeTagsSetter={setActiveTags} startChecked/>
+                <TagToggleGroup group={serviceTags} shopId={shopId} session={session} activeTags={activeTags}
+                                activeTagsSetter={setActiveTags} startChecked/>
+            </div>
         </>
     )
 }
 
-export function TagToggleGroup({group, shopId, session, activeTags, activeTagsSetter}: TagToggleGroupProps) {
+export function TagToggleGroup ({group, shopId, session, activeTags, startChecked, activeTagsSetter}: TagToggleGroupProps) {
 
     const handleTagButtonChanged = (event: any) => {
-        if(session) {
+        if (session) {
             const isChecked = event.currentTarget.checked
             const tagId = event.target.id
 
@@ -76,13 +87,13 @@ export function TagToggleGroup({group, shopId, session, activeTags, activeTagsSe
 
             if (!isChecked) {
                 const requestHeaders = requestDeleteHeaders(body, session)
-                fetch('/apis/activeTag', requestHeaders).then(response => {
+                fetch('/apis/activeTag', requestHeaders).then(() => {
                         fetchActiveTags(shopId, activeTagsSetter, session).then()
                     }
                 )
             } else {
                 const requestHeaders = requestPostHeaders(body, session)
-                fetch('/apis/activeTag', requestHeaders).then(response => {
+                fetch('/apis/activeTag', requestHeaders).then(() => {
                         fetchActiveTags(shopId, activeTagsSetter, session).then()
                     }
                 )
@@ -92,11 +103,13 @@ export function TagToggleGroup({group, shopId, session, activeTags, activeTagsSe
 
     return (
         <>
-            <details className={"collapse collapse-arrow"}>
-                <summary className={"collapse-title text-xl font-medium"}>
+            <div className={'collapse collapse-arrow'}>
+                <input type={'checkbox'} name={'filter-accordion'} className={'min-w-full'}
+                       defaultChecked={startChecked ?? false}/>
+                <div className={'collapse-title text-xl font-medium'}>
                     <div className={'divider'}>{group.group}</div>
-                </summary>
-                <div className={"collapse-content"}>
+                </div>
+                <div className={'collapse-content'}>
                     <div className={'flex flex-wrap gap-6 justify-around'}>
                         {group.tags
                             .sort((a: Tag, b: Tag) => b.count - a.count)
@@ -105,7 +118,7 @@ export function TagToggleGroup({group, shopId, session, activeTags, activeTagsSe
                                                           handleChanged={handleTagButtonChanged}/>)}
                     </div>
                 </div>
-            </details>
+            </div>
         </>
     )
 }


### PR DESCRIPTION
The groups all use checkbox inputs for collapsing now. On mobile, it starts with one group expanded, and at the medium breakpoint it starts with all groups expanded.